### PR TITLE
[KT4-01] Criar testes da função findCreditCard do CreditCardController

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardControllerTest.kt
@@ -18,7 +18,7 @@ class CreditCardControllerTest {
     fun `Should successfully return a CreditCard`() {
         val creditCardReference = getRandomCreditCard()
         val creditCardServiceAdapter = mockk<ICreditCardServiceAdapter> {
-            every { findCreditCardById(any()) } returns getRandomCreditCard()
+            every { findCreditCardById(any()) } returns creditCardReference
         }
         val creditCardController = CreditCardController(creditCardServiceAdapter)
         val result = creditCardController.findCreditCard("")

--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardControllerTest.kt
@@ -1,0 +1,61 @@
+package io.devpass.creditcard.transport
+
+import io.devpass.creditcard.domain.exceptions.EntityNotFoundException
+import io.devpass.creditcard.domain.objects.CreditCard
+import io.devpass.creditcard.domainaccess.ICreditCardServiceAdapter
+import io.devpass.creditcard.transport.controllers.CreditCardController
+import io.mockk.every
+import io.mockk.mockk
+import org.hibernate.TransactionException
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+
+class CreditCardControllerTest {
+
+    @Test
+    fun `Should successfully return a CreditCard`() {
+        val creditCardReference = getRandomCreditCard()
+        val creditCardServiceAdapter = mockk<ICreditCardServiceAdapter> {
+            every { findCreditCardById(any()) } returns getRandomCreditCard()
+        }
+        val creditCardController = CreditCardController(creditCardServiceAdapter)
+        val result = creditCardController.findCreditCard("")
+        Assertions.assertEquals(creditCardReference, result)
+    }
+
+    @Test
+    fun `Should raise an EntityNotFoundException when findCreditCardById returns null`() {
+        val creditCardServiceAdapter = mockk<ICreditCardServiceAdapter> {
+            every { findCreditCardById(any()) } returns null
+        }
+        val creditCardController = CreditCardController(creditCardServiceAdapter)
+        assertThrows<EntityNotFoundException> {
+            creditCardController.findCreditCard("")
+        }
+    }
+
+    @Test
+    fun `Should leak and exception whem findCreditCardById throws and exception himself`() {
+        val creditCardServiceAdapter = mockk<ICreditCardServiceAdapter> {
+            every { findCreditCardById(any()) } throws TransactionException("Forced exception for unit testing purposes")
+        }
+        val creditCardController = CreditCardController(creditCardServiceAdapter)
+        assertThrows<TransactionException> {
+            creditCardController.findCreditCard("")
+        }
+    }
+
+    private fun getRandomCreditCard(): CreditCard {
+        return CreditCard(
+            id = "",
+            owner = "",
+            number = "",
+            securityCode = "",
+            printedName = "",
+            creditLimit = 0.0,
+            availableCreditLimit = 0.0,
+        )
+    }
+}


### PR DESCRIPTION
## O que é

Escrever testes que cubram 100% das linhas da função `findCreditCard` do `CreditCardController`.

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `transport` dentro do módulo `test`


<img width="432" alt="Captura de Tela 2022-09-29 às 16 04 32" src="https://user-images.githubusercontent.com/53983763/193120850-78b1821c-39b2-4102-9614-31ca20276ace.png">

