### PR TITLE
[KT4-04] Criar testes da função generateInvoice do CreditCardInvoiceController

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardInvoiceControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardInvoiceControllerTest.kt
@@ -1,0 +1,52 @@
+package io.devpass.creditcard.transport
+
+import io.devpass.creditcard.domain.exceptions.EntityNotFoundException
+import io.devpass.creditcard.domain.objects.CreditCardInvoice
+import io.devpass.creditcard.domainaccess.ICreditCardInvoiceServiceAdapter
+import io.devpass.creditcard.transport.controllers.CreditCardInvoiceController
+import io.devpass.creditcard.transport.requests.InvoiceCreationRequest
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class CreditCardInvoiceControllerTest() {
+
+    @Test
+    fun `Should generate an invoice`() {
+        val invoiceCreationRequest = InvoiceCreationRequest(creditCardId = "")
+        val invoiceReference = mockCreditCardInvoice()
+        val creditCardInvoiceServiceAdapter = (mockk<ICreditCardInvoiceServiceAdapter> {
+            every { generateInvoice(any()) } returns mockCreditCardInvoice()
+        })
+        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
+        val result = creditCardInvoiceController.generateInvoice(invoiceCreationRequest)
+        assertEquals(invoiceReference, result)
+    }
+
+    @Test
+    fun `Should throw EntityNotFoundException`() {
+        val invoiceCreationRequest = InvoiceCreationRequest(creditCardId = "")
+        val creditCardInvoiceServiceAdapter = (mockk<ICreditCardInvoiceServiceAdapter> {
+            every { generateInvoice(any()) } throws EntityNotFoundException("Throw EntityNotFoundException for testing")
+        })
+        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
+        assertThrows<EntityNotFoundException> {
+            creditCardInvoiceController.generateInvoice(invoiceCreationRequest)
+        }
+    }
+
+    private fun mockCreditCardInvoice(): CreditCardInvoice {
+        return CreditCardInvoice(
+            id = "",
+            creditCard = "",
+            month = 0,
+            year = 0,
+            value = 0.0,
+            createdAt = LocalDateTime.now(),
+            paidAt = null,
+        )
+    }
+}

--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardInvoiceControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardInvoiceControllerTest.kt
@@ -19,7 +19,7 @@ class CreditCardInvoiceControllerTest() {
         val invoiceCreationRequest = InvoiceCreationRequest(creditCardId = "")
         val invoiceReference = mockCreditCardInvoice()
         val creditCardInvoiceServiceAdapter = (mockk<ICreditCardInvoiceServiceAdapter> {
-            every { generateInvoice(any()) } returns mockCreditCardInvoice()
+            every { generateInvoice(any()) } returns invoiceReference
         })
         val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
         val result = creditCardInvoiceController.generateInvoice(invoiceCreationRequest)
@@ -30,10 +30,10 @@ class CreditCardInvoiceControllerTest() {
     fun `Should throw EntityNotFoundException`() {
         val invoiceCreationRequest = InvoiceCreationRequest(creditCardId = "")
         val creditCardInvoiceServiceAdapter = (mockk<ICreditCardInvoiceServiceAdapter> {
-            every { generateInvoice(any()) } throws EntityNotFoundException("Throw EntityNotFoundException for testing")
+            every { generateInvoice(any()) } throws Exception("Throw Exception for testing")
         })
         val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
-        assertThrows<EntityNotFoundException> {
+        assertThrows<Exception> {
             creditCardInvoiceController.generateInvoice(invoiceCreationRequest)
         }
     }

--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardInvoiceControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardInvoiceControllerTest.kt
@@ -27,7 +27,7 @@ class CreditCardInvoiceControllerTest() {
     }
 
     @Test
-    fun `Should throw EntityNotFoundException`() {
+    fun `Should throw Exception`() {
         val invoiceCreationRequest = InvoiceCreationRequest(creditCardId = "")
         val creditCardInvoiceServiceAdapter = (mockk<ICreditCardInvoiceServiceAdapter> {
             every { generateInvoice(any()) } throws Exception("Throw Exception for testing")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10763483/193133266-3b025269-ba3a-4b1e-bcdb-377a233ddc7e.png)

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `transport` dentro do módulo `test`