### PR TITLE
WIP[KT4-03] Testes do método getById da CreditCardInvoiceController

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardInvoiceControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardInvoiceControllerTest.kt
@@ -1,0 +1,66 @@
+package io.devpass.creditcard.transport
+
+import io.devpass.creditcard.domain.exceptions.EntityNotFoundException
+import io.devpass.creditcard.domain.objects.CreditCardInvoice
+import io.devpass.creditcard.domainaccess.ICreditCardInvoiceServiceAdapter
+import io.devpass.creditcard.transport.controllers.CreditCardInvoiceController
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class CreditCardInvoiceControllerTest {
+
+    @Test
+    fun `should throw an EntityNotFoundException when getById method returns null`() {
+        val creditCardInvoiceServiceAdapter = mockk<ICreditCardInvoiceServiceAdapter> {
+            every { getById(any()) } returns null
+        }
+
+        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
+
+        assertThrows<EntityNotFoundException> {
+            creditCardInvoiceController.getById(creditCardInvoiceId = "")
+        }
+    }
+
+    @Test
+    fun `should get credit card invoice by ID`() {
+        val creditCardInvoiceReference = getRandomCreditCardInvoice()
+        val creditCardInvoiceServiceAdapter = mockk<ICreditCardInvoiceServiceAdapter> {
+            every { getById(any()) } returns getRandomCreditCardInvoice()
+        }
+
+        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
+
+        val result = creditCardInvoiceController.getById(creditCardInvoiceId = "")
+        Assertions.assertEquals(creditCardInvoiceReference, result)
+    }
+
+    @Test
+    fun `should leak an exception when getById method throws an exception`() {
+        val creditCarInvoiceServicedapter = mockk<ICreditCardInvoiceServiceAdapter> {
+            every { getById(any()) } throws EntityNotFoundException("Forced exception for unit testing purposes")
+        }
+
+        val creditCardInvoiceController = CreditCardInvoiceController(creditCarInvoiceServicedapter)
+
+        assertThrows<EntityNotFoundException> {
+            creditCardInvoiceController.getById(creditCardInvoiceId = "")
+        }
+    }
+
+    private fun getRandomCreditCardInvoice(): CreditCardInvoice {
+        return CreditCardInvoice(
+            id = "",
+            creditCard = "",
+            month = 1,
+            year = 2002,
+            value = 1000.0,
+            createdAt = LocalDateTime.now(),
+            paidAt = LocalDateTime.now(),
+        )
+    }
+}

--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardInvoiceControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardInvoiceControllerTest.kt
@@ -30,7 +30,7 @@ class CreditCardInvoiceControllerTest {
     fun `should get credit card invoice by ID`() {
         val creditCardInvoiceReference = getRandomCreditCardInvoice()
         val creditCardInvoiceServiceAdapter = mockk<ICreditCardInvoiceServiceAdapter> {
-            every { getById(any()) } returns getRandomCreditCardInvoice()
+            every { getById(any()) } returns creditCardInvoiceReference
         }
 
         val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)


### PR DESCRIPTION
## O que é

Escrever testes que cubram 100% das linhas da função `getById` do `CreditCardInvoiceController`.

![Captura de Tela 2022-09-29 às 18 12 07](https://user-images.githubusercontent.com/54971305/193143164-d188e0cc-7a37-420a-b201-5f861a915cc2.png)

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `transport` dentro do módulo `test`