### PR TITLE
[KT04-09] Teste do método charge

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/controllers/CreditCardOperationControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/controllers/CreditCardOperationControllerTest.kt
@@ -1,0 +1,52 @@
+package io.devpass.creditcard.transport.controllers
+
+import io.devpass.creditcard.domain.objects.CreditCardOperation
+import io.devpass.creditcard.domainaccess.ICreditCardOperationServiceAdapter
+import io.devpass.creditcard.transport.requests.CreditCardChargeRequest
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class CreditCardOperationControllerTest {
+
+
+    //TESTAR O METODO CHARGE
+    // O METODO CHARGE BATE NO SERIVCE E RETORNA UMA LISTA DE CREDITCARD OP
+
+    @Test
+    fun `should return a list of credit card operations`(){
+        //mockar o adapter
+        val request = CreditCardChargeRequest(
+            creditCardId = "",
+            value = 0.0,
+            installments = 1,
+            description = "",
+
+        )
+        val creditCardOperation = getRandomCreditCardOperation()
+        val creditCardOperationService = mockk<ICreditCardOperationServiceAdapter>{
+            every { charge(any()) } returns listOf(creditCardOperation)
+        }
+
+        val creditCardOperationController = CreditCardOperationController(creditCardOperationService)
+
+        val result = creditCardOperationController.charge(request)
+
+        Assertions.assertEquals(listOf(creditCardOperation), result)
+    }
+
+    private fun getRandomCreditCardOperation() : CreditCardOperation{
+        return CreditCardOperation(
+            id = "",
+            creditCard = "",
+            type = "",
+            value = 0.0,
+            month = 1,
+            year = 2022,
+            description = "",
+            createdAt = LocalDateTime.now(),
+        )
+    }
+}

--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/controllers/CreditCardOperationControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/controllers/CreditCardOperationControllerTest.kt
@@ -11,22 +11,17 @@ import java.time.LocalDateTime
 
 class CreditCardOperationControllerTest {
 
-
-    //TESTAR O METODO CHARGE
-    // O METODO CHARGE BATE NO SERIVCE E RETORNA UMA LISTA DE CREDITCARD OP
-
     @Test
-    fun `should return a list of credit card operations`(){
-        //mockar o adapter
+    fun `should return a list of credit card operations`() {
         val request = CreditCardChargeRequest(
             creditCardId = "",
             value = 0.0,
             installments = 1,
             description = "",
 
-        )
+            )
         val creditCardOperation = getRandomCreditCardOperation()
-        val creditCardOperationService = mockk<ICreditCardOperationServiceAdapter>{
+        val creditCardOperationService = mockk<ICreditCardOperationServiceAdapter> {
             every { charge(any()) } returns listOf(creditCardOperation)
         }
 
@@ -37,7 +32,7 @@ class CreditCardOperationControllerTest {
         Assertions.assertEquals(listOf(creditCardOperation), result)
     }
 
-    private fun getRandomCreditCardOperation() : CreditCardOperation{
+    private fun getRandomCreditCardOperation(): CreditCardOperation {
         return CreditCardOperation(
             id = "",
             creditCard = "",


### PR DESCRIPTION

![Captura de Tela 2022-09-30 às 15 34 15](https://user-images.githubusercontent.com/54971305/193334972-07754f47-1cff-4ea6-9ac5-74d46aad9f29.png)

## O que é

Escrever testes que cubram 100% das linhas da função `charge` do `CreditCardOperationController`.

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `transport` dentro do módulo `test`