### PR TITLE
[KT4-08] Criar testes da função getById do CreditCardOperationController

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardOperationControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardOperationControllerTest.kt
@@ -1,0 +1,61 @@
+package io.devpass.creditcard.transport
+
+import io.devpass.creditcard.domain.exceptions.EntityNotFoundException
+import io.devpass.creditcard.domain.objects.CreditCardOperation
+import io.devpass.creditcard.domainaccess.ICreditCardOperationServiceAdapter
+import io.devpass.creditcard.transport.controllers.CreditCardOperationController
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class CreditCardOperationControllerTest {
+
+    @Test
+    fun `Should get credit card operation by ID`() {
+        val creditCardOperationReference = getRandomCreditCardOperation()
+        val creditCardOperationServiceAdapter = mockk<ICreditCardOperationServiceAdapter> {
+            every { getById(any()) } returns creditCardOperationReference
+        }
+        val creditCardOperationController = CreditCardOperationController(creditCardOperationServiceAdapter)
+        val result = creditCardOperationController.getById(creditCardOperationId = "")
+        Assertions.assertEquals(creditCardOperationReference, result)
+    }
+
+    @Test
+    fun `Should throw an EntityNotFoundException when getById method returns null`() {
+        val creditCardOperationServiceAdapter = mockk<ICreditCardOperationServiceAdapter> {
+            every { getById(any()) } returns null
+        }
+        val creditCardOperationController = CreditCardOperationController(creditCardOperationServiceAdapter)
+        assertThrows<EntityNotFoundException> {
+            creditCardOperationController.getById(creditCardOperationId = "")
+        }
+    }
+
+    @Test
+    fun `Should leak an exception when getById method throws an exception`() {
+        val creditCardOperationServiceAdapter = mockk<ICreditCardOperationServiceAdapter> {
+            every { getById(any()) } throws Exception("Throws Exception for testing")
+        }
+        val creditCardOperationController = CreditCardOperationController(creditCardOperationServiceAdapter)
+        assertThrows<Exception> {
+            creditCardOperationController.getById(creditCardOperationId = "")
+        }
+    }
+
+    private fun getRandomCreditCardOperation(): CreditCardOperation {
+        return CreditCardOperation(
+            id = "",
+            creditCard = "",
+            type = "",
+            value = 0.0,
+            month = 0,
+            year = 0,
+            description = "",
+            createdAt = LocalDateTime.now(),
+        )
+    }
+}


### PR DESCRIPTION
![Captura de Tela 2022-09-30 às 15 43 35](https://user-images.githubusercontent.com/10763483/193336367-83f9472d-07fc-43e3-be43-21911c5b5626.png)

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `transport` dentro do módulo `test`