### PR TITLE
[KT4-11] Criar testes da função findCreditCardById do CreditCardService

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/domain/CreditCardServiceTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/domain/CreditCardServiceTest.kt
@@ -1,0 +1,61 @@
+package io.devpass.creditcard.domain
+
+
+import io.devpass.creditcard.dataaccess.IAccountManagementGateway
+import io.devpass.creditcard.dataaccess.IAntiFraudGateway
+import io.devpass.creditcard.dataaccess.ICreditCardDAO
+import io.devpass.creditcard.domain.exceptions.EntityNotFoundException
+import io.devpass.creditcard.domain.objects.CreditCard
+import io.devpass.creditcard.domainaccess.ICreditCardServiceAdapter
+import io.devpass.creditcard.transport.controllers.CreditCardController
+import io.mockk.every
+import io.mockk.mockk
+import org.hibernate.TransactionException
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+
+class CreditCardServiceTest {
+
+    @Test
+    fun `Should successfully return a CreditCardId`() {
+        val creditCardReference = getRandomCreditCard()
+        val antiFraudGateway = mockk<IAntiFraudGateway>()
+        val accountManagementGateway = mockk<IAccountManagementGateway>()
+        val creditCardDAO = mockk<ICreditCardDAO> {
+            every { getById(any()) } returns creditCardReference
+        }
+        val creditCardService = CreditCardService(creditCardDAO, antiFraudGateway, accountManagementGateway)
+        val result = creditCardService.findCreditCardById("")
+        Assertions.assertEquals(creditCardReference, result)
+    }
+
+
+    @Test
+    fun `Should leak and exception when findCreditCardById throws and exception himself`() {
+        val antiFraudGateway = mockk<IAntiFraudGateway>()
+        val accountManagementGateway = mockk<IAccountManagementGateway>()
+        val creditCardDAO = mockk<ICreditCardDAO> {
+            every { getById(any()) } throws TransactionException("Forced exception for unit testing purposes")
+        }
+        val creditCardService = CreditCardService(creditCardDAO, antiFraudGateway, accountManagementGateway)
+        assertThrows<TransactionException> {
+            creditCardService.findCreditCardById("")
+        }
+    }
+
+    private fun getRandomCreditCard(): CreditCard {
+        return CreditCard(
+            id = "",
+            owner = "",
+            number = "",
+            securityCode = "",
+            printedName = "",
+            creditLimit = 0.0,
+            availableCreditLimit = 0.0,
+        )
+    }
+}
+
+


### PR DESCRIPTION
## O que é

Escrever testes que cubram 100% das linhas da função `findCreditCardById` do `CreditCardService`.

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `domain` dentro do módulo `test`

<img width="718" alt="Captura de Tela 2022-09-30 às 16 00 19" src="https://user-images.githubusercontent.com/53983763/193338927-1fd25721-2c38-4fb3-a42e-1188e1c473d7.png">