### PR TITLE
[KT4-06] Cria testes das funções do CreditCardInvoiceController

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/transport/CreditCardInvoiceControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/transport/CreditCardInvoiceControllerTest.kt
@@ -14,51 +14,6 @@ import org.junit.jupiter.api.assertThrows
 import java.time.LocalDateTime
 
 internal class CreditCardInvoiceControllerTest {
-
-    @Test
-    fun `Should successfully return a CreditCardInvoiceId`(){
-        val creditCardInvoiceReference = getRandomCreditCardInvoice()
-        val creditCardInvoiceServiceAdapter = mockk<ICreditCardInvoiceServiceAdapter> {
-            every { getById(any()) } returns getRandomCreditCardInvoice()
-        }
-        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
-        val result = creditCardInvoiceController.getById("")
-        Assertions.assertEquals(creditCardInvoiceReference, result)
-    }
-
-    @Test
-    fun `Should raise an EntityNotFoundException when CreditCardInvoice not found with ID`(){
-        val creditCardInvoiceServiceAdapter = mockk<ICreditCardInvoiceServiceAdapter> {
-            every { getById(any()) } returns null
-        }
-        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
-        assertThrows<EntityNotFoundException> {
-            creditCardInvoiceController.getById("")
-        }
-    }
-
-    @Test
-    fun `Should successfully generateInvoice`(){
-        val creditCardInvoiceReference = getRandomCreditCardInvoice()
-        val creditCardInvoiceServiceAdapter = mockk<ICreditCardInvoiceServiceAdapter> {
-            every { generateInvoice(any()) } returns getRandomCreditCardInvoice()
-        }
-        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
-        val result = creditCardInvoiceController.generateInvoice(InvoiceCreationRequest(creditCardId = ""))
-        Assertions.assertEquals(creditCardInvoiceReference, result)
-    }
-
-    @Test
-    fun `Should successfully when an invoice is paid`(){
-        val payInvoiceStringReference = "Invoice paid successfully"
-        val creditCardInvoiceServiceAdapter = mockk<ICreditCardInvoiceServiceAdapter> {
-            every { payInvoice(any()) } returns Unit
-        }
-        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
-        val result = creditCardInvoiceController.payInvoice(String())
-        Assertions.assertEquals(payInvoiceStringReference, result)
-    }
-
     @Test
     fun `Should successfully return a period`(){
         val creditCardInvoiceReference = getRandomCreditCardInvoice()

--- a/solutions/devsprint-luiz-zytkowski-4/src/test/transport/CreditCardInvoiceControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/transport/CreditCardInvoiceControllerTest.kt
@@ -1,0 +1,106 @@
+package transport
+
+import io.devpass.creditcard.domain.exceptions.EntityNotFoundException
+import io.devpass.creditcard.domain.objects.CreditCardInvoice
+import io.devpass.creditcard.domainaccess.ICreditCardInvoiceServiceAdapter
+import io.devpass.creditcard.transport.controllers.CreditCardInvoiceController
+import io.devpass.creditcard.transport.requests.InvoiceCreationRequest
+import io.mockk.every
+import io.mockk.mockk
+import org.hibernate.TransactionException
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+internal class CreditCardInvoiceControllerTest {
+
+    @Test
+    fun `Should successfully return a CreditCardInvoiceId`(){
+        val creditCardInvoiceReference = getRandomCreditCardInvoice()
+        val creditCardInvoiceServiceAdapter = mockk<ICreditCardInvoiceServiceAdapter> {
+            every { getById(any()) } returns getRandomCreditCardInvoice()
+        }
+        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
+        val result = creditCardInvoiceController.getById("")
+        Assertions.assertEquals(creditCardInvoiceReference, result)
+    }
+
+    @Test
+    fun `Should raise an EntityNotFoundException when CreditCardInvoice not found with ID`(){
+        val creditCardInvoiceServiceAdapter = mockk<ICreditCardInvoiceServiceAdapter> {
+            every { getById(any()) } returns null
+        }
+        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
+        assertThrows<EntityNotFoundException> {
+            creditCardInvoiceController.getById("")
+        }
+    }
+
+    @Test
+    fun `Should successfully generateInvoice`(){
+        val creditCardInvoiceReference = getRandomCreditCardInvoice()
+        val creditCardInvoiceServiceAdapter = mockk<ICreditCardInvoiceServiceAdapter> {
+            every { generateInvoice(any()) } returns getRandomCreditCardInvoice()
+        }
+        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
+        val result = creditCardInvoiceController.generateInvoice(InvoiceCreationRequest(creditCardId = ""))
+        Assertions.assertEquals(creditCardInvoiceReference, result)
+    }
+
+    @Test
+    fun `Should successfully when an invoice is paid`(){
+        val payInvoiceStringReference = "Invoice paid successfully"
+        val creditCardInvoiceServiceAdapter = mockk<ICreditCardInvoiceServiceAdapter> {
+            every { payInvoice(any()) } returns Unit
+        }
+        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
+        val result = creditCardInvoiceController.payInvoice(String())
+        Assertions.assertEquals(payInvoiceStringReference, result)
+    }
+
+    @Test
+    fun `Should successfully return a period`(){
+        val creditCardInvoiceReference = getRandomCreditCardInvoice()
+        val creditCardInvoiceServiceAdapter = mockk<ICreditCardInvoiceServiceAdapter> {
+            every { getByPeriod(any(), any(), any()) } returns getRandomCreditCardInvoice()
+        }
+        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
+        val result = creditCardInvoiceController.getByPeriod("", month = 1, year = 1)
+        Assertions.assertEquals(creditCardInvoiceReference, result)
+    }
+
+    @Test
+    fun `Should raise an EntityNotFoundException when getByPeriod returns null`(){
+        val creditCardInvoiceServiceAdapter = mockk<ICreditCardInvoiceServiceAdapter> {
+            every { getByPeriod(any(), any(), any()) } returns null
+        }
+        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
+        assertThrows<EntityNotFoundException> {
+            creditCardInvoiceController.getByPeriod("", 1, 0)
+        }
+    }
+
+    @Test
+    fun `Should raise an exception when getByPeriod throws an exception`(){
+        val creditCardInvoiceServiceAdapter = mockk<ICreditCardInvoiceServiceAdapter> {
+            every { getByPeriod(any(), any(), any()) } throws TransactionException("Error")
+        }
+        val creditCardInvoiceController = CreditCardInvoiceController(creditCardInvoiceServiceAdapter)
+        assertThrows<TransactionException> {
+            creditCardInvoiceController.getByPeriod("", 1, 0)
+        }
+    }
+
+    private fun getRandomCreditCardInvoice(): CreditCardInvoice {
+        return CreditCardInvoice(
+                id = "",
+                creditCard = "",
+                month = 1,
+                year = 1,
+                value = 0.0,
+                paidAt = LocalDateTime.MAX,
+                createdAt = LocalDateTime.MAX
+        )
+    }
+}


### PR DESCRIPTION
## Descrição 

Escrever testes que cubram 100% das linhas da função getByPeriod do CreditCardInvoiceController.

![Captura de Tela 2022-09-30 às 17 30 25](https://user-images.githubusercontent.com/29679646/193351852-c09e087e-ddf1-410a-bf75-e44f63cc937f.png)

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `transport` dentro do módulo `test`