### PR TITLE
[KT4-02] Criar testes da função requestCreditCard do CreditCardController

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardControllerTest.kt
@@ -4,6 +4,7 @@ import io.devpass.creditcard.domain.exceptions.EntityNotFoundException
 import io.devpass.creditcard.domain.objects.CreditCard
 import io.devpass.creditcard.domainaccess.ICreditCardServiceAdapter
 import io.devpass.creditcard.transport.controllers.CreditCardController
+import io.devpass.creditcard.transport.requests.CreditCardCreationRequest
 import io.mockk.every
 import io.mockk.mockk
 import org.hibernate.TransactionException
@@ -44,6 +45,27 @@ class CreditCardControllerTest {
         val creditCardController = CreditCardController(creditCardServiceAdapter)
         assertThrows<TransactionException> {
             creditCardController.findCreditCard("")
+        }
+    }
+
+    @Test
+    fun `Should request a credit card`() {
+        val creditCardCreationRequest = CreditCardCreationRequest(taxId = "", printedName = "")
+        val randomCreditCardReference = getRandomCreditCard()
+        val creditCardServiceAdapter = mockk<ICreditCardServiceAdapter> {
+            every { requestCreation(any()) } returns randomCreditCardReference
+        }
+        val creditCardController = CreditCardController(creditCardServiceAdapter)
+        val result = creditCardController.requestCreditCard(creditCardCreationRequest)
+        Assertions.assertEquals(randomCreditCardReference, result)
+    }
+
+    @Test
+    fun `Should raise an exception`() {
+        val creditCardCreationRequest = CreditCardCreationRequest(taxId = "", printedName = "")
+        val randomCreditCardReference = getRandomCreditCard()
+        val creditCardServiceAdapter = mockk<ICreditCardServiceAdapter> {
+            every { requestCreation(any()) } throws Exception("Throw Exception for testing")
         }
     }
 

--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardControllerTest.kt
@@ -63,9 +63,12 @@ class CreditCardControllerTest {
     @Test
     fun `Should raise an exception`() {
         val creditCardCreationRequest = CreditCardCreationRequest(taxId = "", printedName = "")
-        val randomCreditCardReference = getRandomCreditCard()
         val creditCardServiceAdapter = mockk<ICreditCardServiceAdapter> {
             every { requestCreation(any()) } throws Exception("Throw Exception for testing")
+        }
+        val creditCardController = CreditCardController(creditCardServiceAdapter)
+        assertThrows<Exception> {
+            creditCardController.requestCreditCard(creditCardCreationRequest)
         }
     }
 


### PR DESCRIPTION
## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `transport` dentro do módulo `test`