### PR TITLE
[KT4-13] Criar testes da função getById do CreditCardOperationService

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/domain/CreditCardOperationServiceTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/domain/CreditCardOperationServiceTest.kt
@@ -1,0 +1,77 @@
+package io.devpass.creditcard.domain
+
+import io.devpass.creditcard.dataaccess.ICreditCardDAO
+import io.devpass.creditcard.dataaccess.ICreditCardInvoiceDAO
+import io.devpass.creditcard.dataaccess.ICreditCardOperationDAO
+import io.devpass.creditcard.domain.exceptions.EntityNotFoundException
+import io.devpass.creditcard.domain.objects.CreditCard
+import io.devpass.creditcard.domain.objects.CreditCardOperation
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class CreditCardOperationServiceTest {
+
+    @Test
+    fun `Should successfully return a CreditCardOperationId`() {
+        val creditCardReference = getRandomCreditCard()
+        val creditCardOperationReference = getRandomCreditCardOperation()
+        val creditCardInvoiceDAO = mockk<ICreditCardInvoiceDAO>()
+        val creditCardOperationDAO = mockk<ICreditCardOperationDAO> {
+            every { getOperationById(any()) } returns creditCardOperationReference
+        }
+        val creditCardDAO = mockk<ICreditCardDAO> {
+            every { getById(any()) } returns creditCardReference
+        }
+        val creditCardOperationService =
+            CreditCardOperationService(creditCardDAO, creditCardInvoiceDAO, creditCardOperationDAO)
+        val result = creditCardOperationService.getById("")
+        Assertions.assertEquals(creditCardOperationReference, result)
+    }
+
+    @Test
+    fun `Should leak and exception when findCreditCardById throws and exception himself`() {
+        val creditCardInvoiceDAO = mockk<ICreditCardInvoiceDAO>()
+        val creditCardOperationDAO = mockk<ICreditCardOperationDAO>{
+            every { getOperationById(any()) } throws EntityNotFoundException("Forced exception for unit testing purposes")
+        }
+        val creditCardDAO = mockk<ICreditCardDAO> {
+            every { getById(any()) } throws EntityNotFoundException("Forced exception for unit testing purposes")
+        }
+        val creditCardOperationService =
+            CreditCardOperationService(creditCardDAO, creditCardInvoiceDAO, creditCardOperationDAO)
+        assertThrows<EntityNotFoundException> {
+            creditCardOperationService.getById("")
+        }
+    }
+
+    private fun getRandomCreditCard(): CreditCard {
+        return CreditCard(
+            id = "",
+            owner = "",
+            number = "",
+            securityCode = "",
+            printedName = "",
+            creditLimit = 0.0,
+            availableCreditLimit = 0.0,
+        )
+    }
+
+    private fun getRandomCreditCardOperation(): CreditCardOperation {
+        return CreditCardOperation(
+            id = "",
+            creditCard = "",
+            type = "",
+            value = 0.0,
+            month = 0,
+            year = 0,
+            description = "",
+            createdAt = LocalDateTime.now(),
+        )
+    }
+}
+
+


### PR DESCRIPTION
## O que é

Escrever testes que cubram 100% das linhas da função `getById` do `CreditCardOperationService`.

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `domain` dentro do módulo `test`

<img width="855" alt="Captura de Tela 2022-10-03 às 15 58 55" src="https://user-images.githubusercontent.com/53983763/193657119-1b7fac51-a5c3-4229-81a8-36a4970c2014.png">