### PR TITLE
[KT4-17] Cria testes da função getById do CreditCardInvoiceService

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/domain/CreditCardInvoiceServiceTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/domain/CreditCardInvoiceServiceTest.kt
@@ -4,7 +4,7 @@ import io.devpass.creditcard.dataaccess.*
 import io.devpass.creditcard.domain.objects.CreditCardInvoice
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDateTime
@@ -23,11 +23,11 @@ class CreditCardInvoiceServiceTest {
         val creditCardInvoiceService =
             CreditCardInvoiceService(creditCardDAO, creditCardInvoiceDAO, creditCardOperationDAO, antiFraudGateway)
         val result = creditCardInvoiceService.getById("")
-        Assertions.assertEquals(creditCardInvoiceReference, result)
+        assertEquals(creditCardInvoiceReference, result)
     }
 
     @Test
-    fun `Should leak and exception when findCreditCardById throws and exception himself`() {
+    fun `Should leak an exception when getById throws and exception himself`() {
         val creditCardInvoiceDAO = mockk<ICreditCardInvoiceDAO> {
             every { getInvoiceById(any()) } throws Exception("Forced exception for unit testing purposes")
         }

--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/domain/CreditCardInvoiceServiceTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/domain/CreditCardInvoiceServiceTest.kt
@@ -1,0 +1,55 @@
+package io.devpass.creditcard.domain
+
+import io.devpass.creditcard.dataaccess.*
+import io.devpass.creditcard.domain.objects.CreditCardInvoice
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class CreditCardInvoiceServiceTest {
+
+    @Test
+    fun `Should successfully return a Credit Card Invoice`() {
+        val creditCardInvoiceReference = getRandomCreditCardInvoice()
+        val creditCardInvoiceDAO = mockk<ICreditCardInvoiceDAO> {
+            every { getInvoiceById(any()) } returns creditCardInvoiceReference
+        }
+        val creditCardOperationDAO = mockk<ICreditCardOperationDAO>()
+        val antiFraudGateway = mockk<IAccountManagementGateway>()
+        val creditCardDAO = mockk<ICreditCardDAO>()
+        val creditCardInvoiceService =
+            CreditCardInvoiceService(creditCardDAO, creditCardInvoiceDAO, creditCardOperationDAO, antiFraudGateway)
+        val result = creditCardInvoiceService.getById("")
+        Assertions.assertEquals(creditCardInvoiceReference, result)
+    }
+
+    @Test
+    fun `Should leak and exception when findCreditCardById throws and exception himself`() {
+        val creditCardInvoiceDAO = mockk<ICreditCardInvoiceDAO> {
+            every { getInvoiceById(any()) } throws Exception("Forced exception for unit testing purposes")
+        }
+        val creditCardOperationDAO = mockk<ICreditCardOperationDAO>()
+        val antiFraudGateway = mockk<IAccountManagementGateway>()
+        val creditCardDAO = mockk<ICreditCardDAO>()
+        val creditCardInvoiceService =
+            CreditCardInvoiceService(creditCardDAO, creditCardInvoiceDAO, creditCardOperationDAO, antiFraudGateway)
+        assertThrows<Exception> {
+            creditCardInvoiceService.getById("")
+        }
+    }
+
+    private fun getRandomCreditCardInvoice(): CreditCardInvoice {
+        return CreditCardInvoice(
+            id = "",
+            creditCard = "",
+            month = 0,
+            year = 0,
+            value = 0.0,
+            createdAt = LocalDateTime.now(),
+            paidAt = null
+        )
+    }
+}


### PR DESCRIPTION
![Captura de Tela 2022-10-04 às 12 00 15](https://user-images.githubusercontent.com/10763483/193854669-53a9e55d-b704-4901-85d6-c8b752dce9e3.png)

--- 

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `domain` dentro do módulo `test`