### PR TITLE
[KT4-37] Criar testes da função rollback do CreditCardOperationController

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardOperationControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardOperationControllerTest.kt
@@ -5,7 +5,6 @@ import io.devpass.creditcard.domain.objects.CreditCardOperation
 import io.devpass.creditcard.domainaccess.ICreditCardOperationServiceAdapter
 import io.devpass.creditcard.transport.controllers.CreditCardOperationController
 import io.mockk.every
-import io.mockk.just
 import io.mockk.justRun
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions

--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardOperationControllerTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/transport/CreditCardOperationControllerTest.kt
@@ -5,6 +5,8 @@ import io.devpass.creditcard.domain.objects.CreditCardOperation
 import io.devpass.creditcard.domainaccess.ICreditCardOperationServiceAdapter
 import io.devpass.creditcard.transport.controllers.CreditCardOperationController
 import io.mockk.every
+import io.mockk.just
+import io.mockk.justRun
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -43,6 +45,28 @@ class CreditCardOperationControllerTest {
         val creditCardOperationController = CreditCardOperationController(creditCardOperationServiceAdapter)
         assertThrows<Exception> {
             creditCardOperationController.getById(creditCardOperationId = "")
+        }
+    }
+
+    @Test
+    fun `Should rollback an operation successfully`() {
+        val creditCardOperationServiceAdapter = mockk<ICreditCardOperationServiceAdapter> {
+            justRun { rollback("FAKE-OPERATION-ID") }
+        }
+        val creditCardOperationId = "FAKE-OPERATION-ID"
+        val creditCardOperationController = CreditCardOperationController(creditCardOperationServiceAdapter)
+        val result = creditCardOperationController.rollback("FAKE-OPERATION-ID")
+        Assertions.assertEquals("Operation $creditCardOperationId was rolled back successfully", result)
+    }
+
+    @Test
+    fun `Should leak and exception when rollback throws and exception himself`() {
+        val creditCardOperationServiceAdapter = mockk<ICreditCardOperationServiceAdapter> {
+            every { rollback("FAKE-OPERATION-ID") } throws EntityNotFoundException("Forced exception for unit testing purposes")
+        }
+        val creditCardOperationController = CreditCardOperationController(creditCardOperationServiceAdapter)
+        assertThrows<EntityNotFoundException> {
+            creditCardOperationController.rollback("FAKE-OPERATION-ID")
         }
     }
 


### PR DESCRIPTION
## O que é

Escrever testes que cubram 100% das linhas da função `rollback` do `CreditCardOperationController`.

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `transport` dentro do módulo `test`

<img width="443" alt="Captura de Tela 2022-10-04 às 15 15 39" src="https://user-images.githubusercontent.com/53983763/193894976-5e4ab1c6-2164-46fe-ab41-b6eaec2a14c4.png">
