### PR TITLE
[KT4-21] Criar testes da função getByCPF do AccountManagementGateway

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/AccountManagementGatewayTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/AccountManagementGatewayTest.kt
@@ -1,0 +1,65 @@
+package io.devpass.creditcard.data
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.github.kittinunf.fuel.core.Body
+import com.github.kittinunf.fuel.core.Client
+import com.github.kittinunf.fuel.core.FuelManager
+import com.github.kittinunf.fuel.core.Response
+import io.devpass.creditcard.data.accountmanagement.response.AccountResponse
+import io.devpass.creditcard.domain.exceptions.GatewayException
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+import java.net.URL
+
+class AccountManagementGatewayTest {
+
+    private val originalClient = FuelManager.instance.client
+
+    @AfterEach
+    fun afterEach() {
+        FuelManager.instance.client = originalClient
+    }
+
+    @Test
+    fun `Should find account by Tax ID`() {
+        val expectedResult = AccountResponse("", "", 0.0)
+        val json = jacksonObjectMapper().writeValueAsString(expectedResult)
+        val body = mockk<Body> {
+            every { toByteArray() } returns json.toByteArray()
+            every { toStream() } returns toByteArray().inputStream()
+        }
+        val client = mockk<Client> {
+            every { executeRequest(any()) } returns Response(
+                url = URL("http://devpass-account-management-gateway-test.com"),
+                statusCode = HttpStatus.OK.value(),
+                responseMessage = "OK",
+                body = body,
+            )
+        }
+        FuelManager.instance.client = client
+        val accountManagementGateway = AccountManagementGateway("http://devpass-account-management-gateway-test.com")
+        val accountResponse = accountManagementGateway.getByCPF("")
+        assertEquals(expectedResult.toAccount(), accountResponse)
+    }
+
+    @Test
+    fun `Should throw a GatewatException when account isn't found by Tax ID`() {
+        val client = mockk<Client> {
+            every { executeRequest(any()) } returns Response(
+                url = URL("http://devpass-account-management-gateway-test.com"),
+                statusCode = HttpStatus.BAD_REQUEST.value(),
+                responseMessage = "Error finding account by Tax Id",
+            )
+        }
+        FuelManager.instance.client = client
+        val accountManagementGateway = AccountManagementGateway("http://devpass-account-management-gateway-test.com")
+        assertThrows<GatewayException> {
+            accountManagementGateway.getByCPF("")
+        }
+    }
+}


### PR DESCRIPTION
## O que é

Escrever testes que cubram 100% das linhas da função `getByCPF` do `AccountManagementGateway`.

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.

- [ ]  Teste criado no *package* `data` dentro do módulo `test`

<img width="1158" alt="Captura de Tela 2022-10-05 às 14 14 36" src="https://user-images.githubusercontent.com/59538305/194121253-f60dac78-1675-47ed-ae59-e0ca6d1925fe.png">