### PR TITLE
[WIP] [KT4-22] Cria teste da função withdraw do AccountManagementGateway

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/AccountManagementGatewayTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/AccountManagementGatewayTest.kt
@@ -1,0 +1,63 @@
+package io.devpass.creditcard.data
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.github.kittinunf.fuel.core.Body
+import com.github.kittinunf.fuel.core.Client
+import com.github.kittinunf.fuel.core.FuelManager
+import com.github.kittinunf.fuel.core.Response
+import io.devpass.creditcard.data.http.response.DefaultHttpResponse
+import io.devpass.creditcard.domain.exceptions.GatewayException
+import io.devpass.creditcard.domain.objects.accountmanagement.Transaction
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import java.net.URL
+
+class AccountManagementGatewayTest {
+    private val originalClient = FuelManager.instance.client
+    @AfterEach
+    fun afterEach(){
+        FuelManager.instance.client = originalClient
+    }
+
+    @Test
+    fun `Should successfully process a transaction using withdraw method`(){
+        val expectedResult = DefaultHttpResponse("")
+        val json = jacksonObjectMapper().writeValueAsString(expectedResult)
+        val body = mockk<Body>{
+            every { toByteArray() } returns json.toByteArray()
+            every { toStream() } returns toByteArray().inputStream()
+        }
+        val client = mockk<Client>{
+            every { executeRequest(any()) } returns Response (
+                    url = URL("http://devpass-unit-test.com"),
+                    statusCode = HttpStatus.OK.value(),
+                    responseMessage = "OK.",
+                    body = body,
+                    )
+        }
+        FuelManager.instance.client = client
+
+        val accountManagementGateway = AccountManagementGateway("http://devpass-unit-test.com")
+        val withdrawMethodSuccessResponse = accountManagementGateway.withdraw(Transaction("",10.0))
+        Assertions.assertEquals(expectedResult.toActionResponse(), withdrawMethodSuccessResponse)
+    }
+    @Test
+    fun `Should throw a GatewayException for unsuccessful transactions using withdraw method`(){
+        val client = mockk<Client>{
+            every { executeRequest(any()) } returns Response (
+                    url = URL("http://devpass-unit-test.com"),
+                    statusCode = HttpStatus.UNAUTHORIZED.value(),
+                    responseMessage = "Unable to proceed your request - insufficient funds.",
+            )
+        }
+        FuelManager.instance.client = client
+        val expectedResult = GatewayException("")
+        val accountManagementGateway = AccountManagementGateway("http://devpass-unit-test.com")
+        val withdrawMethodErrorResponse = accountManagementGateway.withdraw(Transaction("", 0.0))
+        Assertions.assertEquals(expectedResult, withdrawMethodErrorResponse)
+    }
+}

--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/AccountManagementGatewayTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/AccountManagementGatewayTest.kt
@@ -13,6 +13,7 @@ import io.mockk.mockk
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpStatus
 import java.net.URL
 
@@ -55,9 +56,9 @@ class AccountManagementGatewayTest {
             )
         }
         FuelManager.instance.client = client
-        val expectedResult = GatewayException("")
         val accountManagementGateway = AccountManagementGateway("http://devpass-unit-test.com")
-        val withdrawMethodErrorResponse = accountManagementGateway.withdraw(Transaction("", 0.0))
-        Assertions.assertEquals(expectedResult, withdrawMethodErrorResponse)
+        assertThrows<GatewayException> {
+            accountManagementGateway.withdraw(Transaction("", 0.0))
+        }
     }
 }


### PR DESCRIPTION
![Captura de Tela 2022-10-05 às 18 07 42](https://user-images.githubusercontent.com/78935223/194163929-a5fbdd38-ed2d-47c3-af35-b012594c59f1.png)

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `data` dentro do módulo `test`

### Obs.: 
O segundo cenário retorna as mensagens esperadas, mas não passa no report. 


![image](https://media.discordapp.net/attachments/1024449066014343249/1027322541422936146/Captura_de_Tela_2022-10-05_as_17.52.31.png)

![image](https://user-images.githubusercontent.com/78935223/194164414-8ee1185e-82b7-4ae8-bf4a-834867e2e16f.png)

