### PR TITLE
[KT4-20] Criar testes da função generateInvoice do CreditCardInvoiceService

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/domain/CreditCardInvoiceServiceTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/domain/CreditCardInvoiceServiceTest.kt
@@ -188,7 +188,7 @@ class CreditCardInvoiceServiceTest {
     fun `Should successfully generate an invoice with value`() {
         val creditCardReference = getRandomCreditCard()
         val creditCardInvoicereference = getCreditCardInvoiceWithValue()
-        val creditCardOperationsReference = getCreditCardOperationsWithValue()
+        val creditCardOperationsReference = getRandomCreditCardOperations()
         val antiFraudGateway = mockk<IAccountManagementGateway>()
         val creditCardDAO = mockk<ICreditCardDAO> {
             every { getById(any()) } returns creditCardReference
@@ -250,31 +250,6 @@ class CreditCardInvoiceServiceTest {
                 creditCard = "",
                 type = "",
                 value = 0.0,
-                month = 0,
-                year = 0,
-                description = "",
-                createdAt = LocalDateTime.now()
-            )
-        )
-    }
-
-    private fun getCreditCardOperationsWithValue(): List<CreditCardOperation> {
-        return listOf(
-            CreditCardOperation(
-                id = "",
-                creditCard = "",
-                type = "",
-                value = 100.0,
-                month = 0,
-                year = 0,
-                description = "",
-                createdAt = LocalDateTime.now()
-            ),
-            CreditCardOperation(
-                id = "",
-                creditCard = "",
-                type = "",
-                value = 100.0,
                 month = 0,
                 year = 0,
                 description = "",

--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/domain/CreditCardInvoiceServiceTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/domain/CreditCardInvoiceServiceTest.kt
@@ -23,7 +23,7 @@ class CreditCardInvoiceServiceTest {
     @Test
     fun `Should successfully list operations by period`() {
         val creditCardInvoiceReference = getCreditCardInvoice()
-        val creditCardReference = getRandomCreditCard()
+        val creditCardReference = getCreditCard()
         val creditCardOperationDAO = mockk<ICreditCardOperationDAO>()
         val antiFraudGateway = mockk<IAccountManagementGateway>()
         val creditCardDAO = mockk<ICreditCardDAO> {
@@ -145,7 +145,7 @@ class CreditCardInvoiceServiceTest {
 
     @Test
     fun `Should throw invoice already generated exception`() {
-        val creditCardReference = getRandomCreditCard()
+        val creditCardReference = getCreditCard()
         val creditCardInvoiceReference = getCreditCardInvoice()
         val creditCardOperationDAO = mockk<ICreditCardOperationDAO>()
         val antiFraudGateway = mockk<IAccountManagementGateway>()
@@ -164,9 +164,9 @@ class CreditCardInvoiceServiceTest {
 
     @Test
     fun `Should successfully generate an invoice`() {
-        val creditCardReference = getRandomCreditCard()
+        val creditCardReference = getCreditCard()
         val creditCardInvoicereference = getCreditCardInvoice()
-        val creditCardOperationsReference = getRandomCreditCardOperations()
+        val creditCardOperationsReference = getCreditCardOperations()
         val antiFraudGateway = mockk<IAccountManagementGateway>()
         val creditCardDAO = mockk<ICreditCardDAO> {
             every { getById(any()) } returns creditCardReference
@@ -186,9 +186,9 @@ class CreditCardInvoiceServiceTest {
 
     @Test
     fun `Should successfully generate an invoice with value`() {
-        val creditCardReference = getRandomCreditCard()
+        val creditCardReference = getCreditCard()
         val creditCardInvoicereference = getCreditCardInvoiceWithValue()
-        val creditCardOperationsReference = getRandomCreditCardOperations()
+        val creditCardOperationsReference = getCreditCardOperationsWithValue()
         val antiFraudGateway = mockk<IAccountManagementGateway>()
         val creditCardDAO = mockk<ICreditCardDAO> {
             every { getById(any()) } returns creditCardReference
@@ -230,8 +230,7 @@ class CreditCardInvoiceServiceTest {
         )
     }
 
-
-    private fun getRandomCreditCard(): CreditCard {
+    private fun getCreditCard(): CreditCard {
         return CreditCard(
             id = "",
             owner = "",
@@ -243,13 +242,28 @@ class CreditCardInvoiceServiceTest {
         )
     }
 
-    private fun getRandomCreditCardOperations(): List<CreditCardOperation> {
+    private fun getCreditCardOperations(): List<CreditCardOperation> {
         return listOf(
             CreditCardOperation(
                 id = "",
                 creditCard = "",
                 type = "",
                 value = 0.0,
+                month = 0,
+                year = 0,
+                description = "",
+                createdAt = LocalDateTime.now()
+            )
+        )
+    }
+
+    private fun getCreditCardOperationsWithValue(): List<CreditCardOperation> {
+        return listOf(
+            CreditCardOperation(
+                id = "",
+                creditCard = "",
+                type = "CHARGE",
+                value = 200.0,
                 month = 0,
                 year = 0,
                 description = "",


### PR DESCRIPTION
## O que é

Escrever testes que cubram 100% das linhas da função `generateInvoice` do `CreditCardInvoiceService`.

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `domain` dentro do módulo `test`


<img width="1011" alt="Captura de Tela 2022-10-05 às 20 03 22" src="https://user-images.githubusercontent.com/53983763/194179484-d2e21556-6a67-41a5-b860-6c89d89115b6.png">

