### PR TITLE
[KT4-25] Criar testes da função creditCardEligibility do AntiFraudGateway

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/AntiFraudGatewayTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/AntiFraudGatewayTest.kt
@@ -1,0 +1,57 @@
+package io.devpass.creditcard.data
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.github.kittinunf.fuel.core.Body
+import com.github.kittinunf.fuel.core.Client
+import com.github.kittinunf.fuel.core.FuelManager
+import com.github.kittinunf.fuel.core.Response
+import io.devpass.creditcard.domain.exceptions.OwnedException
+import io.devpass.creditcard.domain.objects.antifraud.CreditCardEligibility
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+import java.net.URL
+
+class AntiFraudGatewayTest {
+
+    @Test
+    fun `Should get creditCardEligibility for the informed CPF`() {
+        val expectedResult = CreditCardEligibility(true, 1.0)
+        val json = jacksonObjectMapper().writeValueAsString(expectedResult)
+        val body = mockk<Body> {
+            every { toByteArray() } returns json.toByteArray()
+            every { toStream() } returns toByteArray().inputStream()
+        }
+        val client = mockk<Client> {
+            every { executeRequest(any()) } returns Response(
+                url = URL("http://devpass-antifraud-gateway-test.com"),
+                statusCode = HttpStatus.OK.value(),
+                responseMessage = "OK",
+                body = body,
+            )
+        }
+        FuelManager.instance.client = client
+        val antiFraudGateway = AntiFraudGateway("http://devpass-antifraud-gateway-test.com")
+        val creditcardEligibilyResponse = antiFraudGateway.creditCardEligibility("")
+        Assertions.assertEquals(expectedResult, creditcardEligibilyResponse)
+    }
+
+    @Test
+    fun `Should throw an OwnedException when creditCardEligibity isn't avaiable for the informed CPF`() {
+        val client = mockk<Client> {
+            every { executeRequest(any()) } returns Response(
+                url = URL("http://devpass-antifraud-gateway-test.com"),
+                statusCode = HttpStatus.BAD_REQUEST.value(),
+                responseMessage = "Error getting eligibility for informed CPF",
+            )
+        }
+        FuelManager.instance.client = client
+        val antiFraudGateway = AntiFraudGateway("http://devpass-antifraud-gateway-test.com")
+        assertThrows<OwnedException> {
+            antiFraudGateway.creditCardEligibility("")
+        }
+    }
+}

--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/AntiFraudGatewayTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/AntiFraudGatewayTest.kt
@@ -9,6 +9,7 @@ import io.devpass.creditcard.domain.exceptions.OwnedException
 import io.devpass.creditcard.domain.objects.antifraud.CreditCardEligibility
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -16,6 +17,13 @@ import org.springframework.http.HttpStatus
 import java.net.URL
 
 class AntiFraudGatewayTest {
+
+    private val originalClient = FuelManager.instance.client
+
+    @AfterEach
+    fun afterEach() {
+        FuelManager.instance.client = originalClient
+    }
 
     @Test
     fun `Should get creditCardEligibility for the informed CPF`() {


### PR DESCRIPTION
## O que é

Escrever testes que cubram 100% das linhas da função `creditCardEligibility` do `AntiFraudGateway`.

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `data` dentro do módulo `test`
<img width="921" alt="Captura de Tela 2022-10-06 às 09 31 29" src="https://user-images.githubusercontent.com/59538305/194313244-bf2e8f39-4988-4d69-9939-614b000fd20d.png">

