### PR TITLE
[KT4-24] Criar testes da função getAccountById do AccountManagementGateway

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/AccountManagementGatewayTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/AccountManagementGatewayTest.kt
@@ -13,6 +13,7 @@ import io.mockk.mockk
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import io.devpass.creditcard.data.accountmanagement.response.AccountResponse
+import io.devpass.creditcard.domain.objects.accountmanagement.Account
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -50,7 +51,7 @@ class AccountManagementGatewayTest {
         val withdrawMethodSuccessResponse = accountManagementGateway.withdraw(Transaction("",10.0))
         Assertions.assertEquals(expectedResult.toActionResponse(), withdrawMethodSuccessResponse)
     }
-    
+
     @Test
     fun `Should throw a GatewayException for unsuccessful transactions using withdraw method`(){
         val client = mockk<Client>{
@@ -66,7 +67,7 @@ class AccountManagementGatewayTest {
             accountManagementGateway.withdraw(Transaction("", 0.0))
         }
     }
-    
+
     @Test
     fun `Should find account by Tax ID`() {
         val expectedResult = AccountResponse("", "", 0.0)
@@ -102,6 +103,44 @@ class AccountManagementGatewayTest {
         val accountManagementGateway = AccountManagementGateway("http://devpass-account-management-gateway-test.com")
         assertThrows<GatewayException> {
             accountManagementGateway.getByCPF("")
+        }
+    }
+
+    @Test
+    fun `Should find account by ID`() {
+        val expectedResult = Account("", "", 0.0)
+        val json = jacksonObjectMapper().writeValueAsString(expectedResult)
+        val body = mockk<Body> {
+            every { toByteArray() } returns json.toByteArray()
+            every { toStream() } returns toByteArray().inputStream()
+        }
+        val client = mockk<Client> {
+            every { executeRequest(any()) } returns Response(
+                url = URL("http://devpass-account-management-gateway-test.com"),
+                statusCode = HttpStatus.OK.value(),
+                responseMessage = "OK",
+                body = body,
+            )
+        }
+        FuelManager.instance.client = client
+        val accountManagementGateway = AccountManagementGateway("http://devpass-account-management-gateway-test.com")
+        val accountResponse = accountManagementGateway.getAccountById("")
+        assertEquals(expectedResult, accountResponse)
+    }
+
+    @Test
+    fun `Should throw a GatewatException when account isn't found by ID`() {
+        val client = mockk<Client> {
+            every { executeRequest(any()) } returns Response(
+                url = URL("http://devpass-account-management-gateway-test.com"),
+                statusCode = HttpStatus.BAD_REQUEST.value(),
+                responseMessage = "Error finding account by Id",
+            )
+        }
+        FuelManager.instance.client = client
+        val accountManagementGateway = AccountManagementGateway("http://devpass-account-management-gateway-test.com")
+        assertThrows<GatewayException> {
+            accountManagementGateway.getAccountById("")
         }
     }
 }


### PR DESCRIPTION
## O que é

Escrever testes que cubram 100% das linhas da função `getAccountById` do `AccountManagementGateway`.

![Captura de Tela 2022-10-06 às 11 26 06](https://user-images.githubusercontent.com/10763483/194341318-c4f415a3-b254-452e-afb4-3adc9f109db0.png)


## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `data` dentro do módulo `test`