### PR TITLE
[KT4-27] Criar testes da função getByTaxId do CreditCardDAO

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/CreditCardDAOTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/CreditCardDAOTest.kt
@@ -1,0 +1,76 @@
+package io.devpass.creditcard.data
+
+import io.devpass.creditcard.data.repositories.CreditCardRepository
+import io.devpass.creditcard.data.entities.CreditCardEntity
+import io.devpass.creditcard.domain.objects.CreditCard
+import org.junit.jupiter.api.Assertions.assertEquals
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class CreditCardDAOTest {
+
+    @Test
+    fun `Should successfully return a CreditCard`() {
+        val creditCardReference = getCreditCard()
+        val creditCardEntity = getListOfCreditCardEntity()
+        val creditCardRepository = mockk<CreditCardRepository> {
+            every { findByTaxId("") } returns creditCardEntity
+        }
+        val creditCardDAO = CreditCardDAO(creditCardRepository)
+        val result = creditCardDAO.getByTaxId("")
+        assertEquals(creditCardReference, result)
+    }
+
+    @Test
+    fun `Should return null if the list is empty`() {
+        val creditCardEntity = listOf<CreditCardEntity>()
+        val creditCardRepository = mockk<CreditCardRepository> {
+            every { findByTaxId("") } returns creditCardEntity
+        }
+        val creditCardDAO = CreditCardDAO(creditCardRepository)
+        val result = creditCardDAO.getByTaxId("")
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun `Should leak an exception when getByTaxId throws an exception himself`() {
+        val creditCardRepository = mockk<CreditCardRepository> {
+            every { findByTaxId(any()) } throws Exception("Forced exception for unit testing purposes")
+        }
+        val creditCardDAO = CreditCardDAO(creditCardRepository)
+        assertThrows<Exception> {
+            creditCardDAO.getByTaxId("")
+        }
+    }
+
+    private fun getListOfCreditCardEntity(): List<CreditCardEntity> {
+        return listOf(
+            CreditCardEntity(
+                id = "",
+                owner = "",
+                number = "",
+                securityCode = "",
+                printedName = "",
+                creditLimit = 0.0,
+                availableCreditLimit = 0.0,
+                createdAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now(),
+            )
+        )
+    }
+
+    private fun getCreditCard(): CreditCard {
+        return CreditCard(
+            id = "",
+            owner = "",
+            number = "",
+            securityCode = "",
+            printedName = "",
+            creditLimit = 0.0,
+            availableCreditLimit = 0.0,
+        )
+    }
+}


### PR DESCRIPTION
## O que é

Escrever testes que cubram 100% das linhas da função `getByTaxId` do `CreditCardDAO`.

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `data` dentro do módulo `test`

<img width="670" alt="Captura de Tela 2022-10-06 às 13 00 08" src="https://user-images.githubusercontent.com/53983763/194364715-217aaa07-d910-4397-a81a-2b09dbea82e6.png">
