### PR TITLE
[KT4-28] Cria testes para função create do CreditCardDAO

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/CreditCardDAOTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/CreditCardDAOTest.kt
@@ -11,7 +11,27 @@ import org.junit.jupiter.api.assertThrows
 import java.time.LocalDateTime
 
 class CreditCardDAOTest {
-
+    @Test
+    fun`Should successfully create a CreditCard`() {
+        val creditCardReference = creditCard()
+        val creditCardEntity = getCreditCardEntity()
+        val creditCardRepository = mockk<CreditCardRepository> {
+            every { save(any()) } returns creditCardEntity
+        }
+        val creditCardDAO = CreditCardDAO(creditCardRepository)
+        val result = creditCardDAO.create(creditCard())
+        assertEquals(creditCardReference, result)
+    }
+    @Test
+    fun `Should leak an exception when create throws an exception himself`() {
+        val creditCardRepository = mockk<CreditCardRepository> {
+            every { save(any()) } throws Exception("Credit card hasn't create")
+        }
+        val creditCardDAO = CreditCardDAO(creditCardRepository)
+        assertThrows<Exception> {
+            creditCardDAO.create(creditCard())
+        }
+    }
     @Test
     fun `Should successfully return a CreditCard`() {
         val creditCardReference = getCreditCard()
@@ -71,6 +91,32 @@ class CreditCardDAOTest {
             printedName = "",
             creditLimit = 0.0,
             availableCreditLimit = 0.0,
+        )
+    }
+
+    private fun creditCard(): CreditCard {
+        return CreditCard(
+                id = "",
+                owner = "",
+                number = "",
+                securityCode = "",
+                printedName = "",
+                creditLimit = 0.0,
+                availableCreditLimit = 0.0,
+        )
+    }
+
+    private fun getCreditCardEntity(): CreditCardEntity {
+        return CreditCardEntity(
+            id = "",
+            owner = "",
+            number = "",
+            securityCode = "",
+            printedName = "",
+            creditLimit = 0.0,
+            availableCreditLimit = 0.0,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
         )
     }
 }


### PR DESCRIPTION
## Descrição 

Escreve testes que cobrem 100% das linhas da função create do CreditCardDAO

![Captura de Tela 2022-10-07 às 16 53 16](https://user-images.githubusercontent.com/29679646/194643102-d707de40-52b0-4f7d-904b-3738ebcad338.png)

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `data` dentro do módulo `test`