### PR TITLE
[KT4-29] Criar testes da função update do CreditCardDAO

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/CreditCardDAOTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/CreditCardDAOTest.kt
@@ -5,10 +5,12 @@ import io.devpass.creditcard.data.entities.CreditCardEntity
 import io.devpass.creditcard.domain.objects.CreditCard
 import org.junit.jupiter.api.Assertions.assertEquals
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDateTime
+import java.util.*
 
 class CreditCardDAOTest {
 
@@ -44,6 +46,32 @@ class CreditCardDAOTest {
         assertThrows<Exception> {
             creditCardDAO.getByTaxId("")
         }
+    }
+
+    @Test
+    fun `Should successfully update a CreditCard`() {
+        val creditCardEntityReference = getCreditCardEntity()
+        val creditCardReference = getCreditCard()
+        val creditCardRepository = mockk<CreditCardRepository>() {
+            every { findById(any()) } returns Optional.of(creditCardEntityReference)
+            justRun { (save(creditCardEntityReference)) }
+        }
+        val creditCardDAO = CreditCardDAO(creditCardRepository)
+        val result = creditCardDAO.update(creditCardReference)
+    }
+
+    private fun getCreditCardEntity(): CreditCardEntity {
+        return CreditCardEntity(
+            id = "",
+            owner = "",
+            number = "",
+            securityCode = "",
+            printedName = "",
+            creditLimit = 0.0,
+            availableCreditLimit = 0.0,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+        )
     }
 
     private fun getListOfCreditCardEntity(): List<CreditCardEntity> {


### PR DESCRIPTION
![Captura de Tela 2022-10-10 às 15 04 55](https://user-images.githubusercontent.com/10763483/194927692-8dfe67ec-cf4b-4eab-9155-a5a8560f6324.png)

---

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `data` dentro do módulo `test`