### PR TITLE
[KT4-36] Cria testes da função listByPeriod do CreditCardOperationDAO

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/CreditCardOperationDAOTest.kt
+++ b/solutions/devsprint-luiz-zytkowski-4/src/test/io/devpass/creditcard/data/CreditCardOperationDAOTest.kt
@@ -1,0 +1,33 @@
+package io.devpass.creditcard.data
+
+import io.devpass.creditcard.data.entities.CreditCardOperationEntity
+import io.devpass.creditcard.data.repositories.CreditCardOperationRepository
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CreditCardOperationDAOTest {
+    @Test
+    fun `Should successfully return a CreditCardOperation`() {
+        val getListCreditCardOperationReference = listOf<CreditCardOperationEntity>()
+        val creditCardOperationRepository = mockk<CreditCardOperationRepository> {
+            every { listByPeriod(any(), any(), any()) } returns getListCreditCardOperationReference
+        }
+        val creditCardOperationDAO = CreditCardOperationDAO(creditCardOperationRepository)
+        val result = creditCardOperationDAO.listByPeriod("", month = 0, 0)
+        assertEquals(getListCreditCardOperationReference, result)
+    }
+
+    @Test
+    fun `Should leak an exception when listByPeriod throws an exception himself`() {
+        val creditCardOperationRepository = mockk<CreditCardOperationRepository> {
+            every { listByPeriod(any(), any(), any()) } throws Exception("Periods not found")
+        }
+        val creditCardOperationDAO = CreditCardOperationDAO(creditCardOperationRepository)
+        assertThrows<Exception> {
+            creditCardOperationDAO.listByPeriod("", 14, 0)
+        }
+    }
+}


### PR DESCRIPTION
## Descrição

Escreve testes que cobrem 100% das linhas da função listByPeriod do CreditCardOperationDAO

![Captura de Tela 2022-10-10 às 13 52 22](https://user-images.githubusercontent.com/29679646/194917149-a79d4cdc-8950-436e-b0dd-31fcf68b5a32.png)

## Critérios de aceite

- [ ]  100% das linhas cobertas segundo relatório do *Kover*.
- [ ]  Teste criado no *package* `data` dentro do módulo `test`
